### PR TITLE
Add a Bulgarian Core in Sofia

### DIFF
--- a/toi/history/states/48-Bulgaria.txt
+++ b/toi/history/states/48-Bulgaria.txt
@@ -21,6 +21,7 @@ state={
 			
 		}
 		add_core_of = OTO
+		add_core_of = BUL
 	}
 
 	provinces={


### PR DESCRIPTION
Most balkan nations except for Bulgaria have cores on Ottoman land. I think Bulgaria should be releasable too. More info in community_content.